### PR TITLE
chore: PR Review changes

### DIFF
--- a/components/TreasuryAccount/HoldTokensTotalPrice.tsx
+++ b/components/TreasuryAccount/HoldTokensTotalPrice.tsx
@@ -1,56 +1,14 @@
-import useProgramSelector from '@components/Mango/useProgramSelector'
-import UseMangoV4 from '@hooks/useMangoV4'
 import { useTotalTreasuryPrice } from '@hooks/useTotalTreasuryPrice'
-import { fetchMangoAccounts } from '@hooks/useTreasuryInfo/assembleWallets'
-import { convertAccountToAsset } from '@hooks/useTreasuryInfo/convertAccountToAsset'
-import { Asset } from '@models/treasury/Asset'
 import { formatNumber } from '@utils/formatNumber'
-import BigNumber from 'bignumber.js'
-import { useEffect, useState } from 'react'
 
 const HoldTokensTotalPrice = () => {
-  const { totalPriceFormatted, assetAccounts } = useTotalTreasuryPrice()
-
-  const programSelectorHook = useProgramSelector()
-  const { mangoClient, mangoGroup } = UseMangoV4(
-    programSelectorHook.program?.val,
-    programSelectorHook.program?.group
-  )
-  const [mangoAccountsValue, setMangoAccountsValue] = useState(new BigNumber(0))
-  const [isFetching, setIsFetching] = useState(true)
-
-  useEffect(() => {
-    async function fetchMangoValue() {
-      const assets = (
-        await Promise.all(assetAccounts.map((a) => convertAccountToAsset(a)))
-      ).filter((asset): asset is Asset => asset !== null)
-
-      const { mangoAccountsValue: newMangoValue } = await fetchMangoAccounts(
-        assets!,
-        mangoClient!,
-        mangoGroup
-      )
-
-      setMangoAccountsValue(newMangoValue)
-    }
-    if (assetAccounts.length > 0 && isFetching && mangoClient && mangoGroup) {
-      fetchMangoValue().finally(() => {
-        setIsFetching(false)
-      })
-    }
-  }, [assetAccounts, isFetching, mangoClient, mangoGroup])
+  const { totalPriceFormatted, isFetching } = useTotalTreasuryPrice()
 
   return (
     <div className="bg-bkg-1 mb-3 px-4 py-2 rounded-md w-full">
       <p className="text-fgd-3">Treasury Balance</p>
       <span className="hero-text">
-        {isFetching
-          ? 'Fetching ...'
-          : `$${formatNumber(
-              totalPriceFormatted.gt(0)
-                ? totalPriceFormatted.plus(mangoAccountsValue)
-                : mangoAccountsValue
-            )}`}
+        {isFetching ? 'Fetching ...' : `$${formatNumber(totalPriceFormatted)}`}
       </span>
     </div>
   )

--- a/components/treasuryV2/WalletList/AuxiliaryWalletListItem/index.tsx
+++ b/components/treasuryV2/WalletList/AuxiliaryWalletListItem/index.tsx
@@ -161,8 +161,6 @@ export default function AuxiliaryWalletListItem(props: Props) {
       </button>
       {isOpen && (
         <AssetList
-          mangoAccounts={props.wallet.mangoAccounts}
-          mangoAccountsValue={props.wallet.mangoAccountsValue}
           assets={props.wallet.assets}
           className="pt-4"
           selectedAssetId={props.selectedAsset?.id}

--- a/components/treasuryV2/WalletList/WalletListItem/AssetList/OtherAssetsList.tsx
+++ b/components/treasuryV2/WalletList/WalletListItem/AssetList/OtherAssetsList.tsx
@@ -20,11 +20,9 @@ import UnknownAssetListItem from './UnknownAssetListItem'
 import RealmAuthorityListItem from './RealmAuthorityListItem'
 import StakeListItem from './StakeListItem'
 import { abbreviateAddress } from '@utils/formatting'
-import BigNumber from 'bignumber.js'
 import MangoListItem from './MangoListItem'
 
 interface Props {
-  mangoAccountsValue: BigNumber
   className?: string
   disableCollapse?: boolean
   expanded?: boolean
@@ -122,7 +120,7 @@ export default function OtherAssetsList(props: Props) {
               return (
                 <MangoListItem
                   key={i}
-                  amount={props.mangoAccountsValue}
+                  amount={asset.value}
                   onSelect={() => []}
                 />
               )

--- a/components/treasuryV2/WalletList/WalletListItem/AssetList/index.tsx
+++ b/components/treasuryV2/WalletList/WalletListItem/AssetList/index.tsx
@@ -40,8 +40,6 @@ import { useRealmConfigQuery } from '@hooks/queries/realmConfig'
 import useTreasuryAddressForGovernance from '@hooks/useTreasuryAddressForGovernance'
 import { useDigitalAssetsByOwner } from '@hooks/queries/digitalAssets'
 import { SUPPORT_CNFTS } from '@constants/flags'
-import { MangoAccount } from '@blockworks-foundation/mango-v4'
-import BigNumber from 'bignumber.js'
 
 export type Section = 'tokens' | 'nfts' | 'others'
 
@@ -78,8 +76,6 @@ interface Props {
   onSelectAsset?(asset: Asset): void
   onToggleExpandSection?(section: Section): void
   governance: PublicKey | undefined
-  mangoAccounts: MangoAccount[]
-  mangoAccountsValue: BigNumber
 }
 
 export default function AssetList(props: Props) {
@@ -249,21 +245,9 @@ export default function AssetList(props: Props) {
       )}
       {others.length > 0 && (
         <OtherAssetsList
-          mangoAccountsValue={props.mangoAccountsValue}
           disableCollapse={!diplayingMultipleAssetTypes}
           expanded={props.expandedSections?.includes('others')}
-          assets={
-            props.mangoAccounts.length > 0
-              ? [
-                  {
-                    id: 'mango',
-                    value: props.mangoAccountsValue,
-                    type: AssetType.Mango,
-                  },
-                  ...others,
-                ]
-              : others
-          }
+          assets={others}
           selectedAssetId={props.selectedAssetId}
           onSelect={props.onSelectAsset}
           onToggleExpand={() => props.onToggleExpandSection?.('others')}

--- a/components/treasuryV2/WalletList/WalletListItem/index.tsx
+++ b/components/treasuryV2/WalletList/WalletListItem/index.tsx
@@ -82,8 +82,6 @@ export default function WalletListItem(props: Props) {
             expandedSections={expandedSections}
             selectedAssetId={props.selectedAsset?.id}
             onSelectAsset={props.onSelectAsset}
-            mangoAccounts={props.wallet.mangoAccounts}
-            mangoAccountsValue={props.wallet.mangoAccountsValue}
             onToggleExpandSection={(section) =>
               setExpandedSections((current) => {
                 if (current.includes(section)) {

--- a/hooks/useTotalTreasuryPrice.ts
+++ b/hooks/useTotalTreasuryPrice.ts
@@ -6,6 +6,7 @@ import { useJupiterPricesByMintsQuery } from './queries/jupiterPrice'
 import { PublicKey } from '@metaplex-foundation/js'
 import { WSOL_MINT } from '@components/instructions/tools'
 import { AccountType } from '@utils/uiTypes/assets'
+import { useMangoAccountsTreasury } from './useMangoAccountsTreasury'
 
 export function useTotalTreasuryPrice() {
   const {
@@ -25,6 +26,10 @@ export function useTotalTreasuryPrice() {
     ...mintsToFetch,
     new PublicKey(WSOL_MINT),
   ])
+
+  const { mangoAccountsValue, isFetching } = useMangoAccountsTreasury(
+    assetAccounts
+  )
 
   const totalTokensPrice = [
     ...governedTokenAccountsWithoutNfts,
@@ -57,12 +62,13 @@ export function useTotalTreasuryPrice() {
 
   const totalPrice = totalTokensPrice + stakeAccountsTotalPrice
 
-  const totalPriceFormatted = governedTokenAccountsWithoutNfts.length
+  const totalPriceFormatted = (governedTokenAccountsWithoutNfts.length
     ? new BigNumber(totalPrice)
     : new BigNumber(0)
+  ).plus(mangoAccountsValue)
 
   return {
+    isFetching,
     totalPriceFormatted,
-    assetAccounts,
   }
 }

--- a/models/treasury/Wallet.ts
+++ b/models/treasury/Wallet.ts
@@ -5,8 +5,7 @@ import type {
   Governance,
 } from '@solana/spl-governance'
 
-import { Asset, Token } from './Asset'
-import { MangoAccount } from '@blockworks-foundation/mango-v4'
+import { Asset, Mango, Sol, Token } from './Asset'
 
 interface CommonRules {
   maxVotingTime: number
@@ -38,14 +37,10 @@ export interface Wallet {
     votingProposalCount?: number
   }
   totalValue: BigNumber
-  mangoAccountsValue: BigNumber
-  mangoAccounts: MangoAccount[]
 }
 
 export interface AuxiliaryWallet {
-  assets: Token[]
+  assets: (Token | Sol | Mango)[]
   name: string
   totalValue: BigNumber
-  mangoAccountsValue: BigNumber
-  mangoAccounts: MangoAccount[]
 }


### PR DESCRIPTION
This PR is about the comments Adrian left over the main repo for the previous commits made for the mango accounts treasury feature. 

1. The mango account value is now inside a seperate hook.
2. The assets now hold a type called Mango. 