### PR TITLE
bugfix: fix duplication of mango accounts value

### DIFF
--- a/hooks/useTreasuryInfo/assembleWallets.tsx
+++ b/hooks/useTreasuryInfo/assembleWallets.tsx
@@ -264,12 +264,11 @@ export const assembleWallets = async (
       name: wallet.governanceAddress
         ? getAccountName(wallet.governanceAddress)
         : getAccountName(wallet.address),
-      totalValue: calculateTotalValue([
-        ...wallet.assets.map((asset) =>
+      totalValue: calculateTotalValue(
+        wallet.assets.map((asset) =>
           'value' in asset ? asset.value : new BigNumber(0)
-        ),
-        mangoAccountsValue,
-      ]),
+        )
+      ),
     })
   }
 
@@ -323,12 +322,11 @@ export const assembleWallets = async (
         {
           assets: auxiliaryAssets,
           name: 'Auxiliary Assets',
-          totalValue: calculateTotalValue([
-            ...auxiliaryAssets.map((asset) =>
+          totalValue: calculateTotalValue(
+            auxiliaryAssets.map((asset) =>
               'value' in asset ? asset.value : new BigNumber(0)
-            ),
-            auxMangoAccountsValue,
-          ]),
+            )
+          ),
         },
       ]
     : []

--- a/hooks/useTreasuryInfo/index.tsx
+++ b/hooks/useTreasuryInfo/index.tsx
@@ -140,7 +140,6 @@ export default function useTreasuryInfo(
       governedTokens: { counts, values },
       name: realmInfo.displayName || realmInfo.symbol,
       totalValue: [...auxWallets, ...wallets].reduce((acc, wallet) => {
-        console.log(wallet.totalValue.toNumber())
         return acc.plus(wallet.totalValue)
       }, new BigNumber(0)),
     },

--- a/hooks/useTreasuryInfo/index.tsx
+++ b/hooks/useTreasuryInfo/index.tsx
@@ -140,6 +140,7 @@ export default function useTreasuryInfo(
       governedTokens: { counts, values },
       name: realmInfo.displayName || realmInfo.symbol,
       totalValue: [...auxWallets, ...wallets].reduce((acc, wallet) => {
+        console.log(wallet.totalValue.toNumber())
         return acc.plus(wallet.totalValue)
       }, new BigNumber(0)),
     },


### PR DESCRIPTION
The mango accounts value was double summing in the /dao/[name]/v2 page. This PR is based on that.